### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ support WebAssembly MVP. Since it's not yet released
 we assume its been downloaded or compiled locally
 and the executable is ../node/node. According to
 [this](https://github.com/nodejs/node/pull/12220#issuecomment-294511442)
-v8.0.0 should be released by end on May 30th 2017.
+v8.0.0 should be released on May 30th, 2017.
 
 I tested by compiling [node](https://github.com/nodejs/node)
 from sources on master branch at sha1


### PR DESCRIPTION
This is a fix for my own typo introduced in 66cea09c7de67eb3077e38b68403c4850881482a